### PR TITLE
Fix exchange_code_for_access_token.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .DS_Store
 *.swp
 test_settings.py
-
+.idea
 build

--- a/instagram/models.py
+++ b/instagram/models.py
@@ -205,6 +205,8 @@ class User(ApiModel):
     def __unicode__(self):
         return "User: %s" % self.username
 
+    def __eq__(self, other):
+        return self.id == other.id
 
 class Relationship(ApiModel):
 

--- a/instagram/models.py
+++ b/instagram/models.py
@@ -208,6 +208,9 @@ class User(ApiModel):
     def __eq__(self, other):
         return self.id == other.id
 
+    def __ne__(self, other):
+        return not self == other
+
 class Relationship(ApiModel):
 
     def __init__(self, incoming_status="none", outgoing_status="none", target_user_is_private=False):

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -109,7 +109,8 @@ class OAuth2AuthExchangeRequest(object):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
         http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
-        response, content = http_object.request(url, method="POST", body=data)
+        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+        response, content = http_object.request(url, method="POST", headers=headers, body=data)
         parsed_content = simplejson.loads(content.decode())
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))


### PR DESCRIPTION
Fixes "instagram.oauth2.OAuth2AuthExchangeError: You must provide a client_id" error

Reference: https://github.com/facebookarchive/python-instagram/pull/249. All credit goes to yousong.