### PR TITLE
fix undocumented id attribute crashing parsing video json

### DIFF
--- a/fixtures/user_recent_media.json
+++ b/fixtures/user_recent_media.json
@@ -79,6 +79,7 @@
             "type": "video",
             "videos": {
                 "low_resolution": {
+                    "id": "0",
                     "url": "http://distilleryvesper9-13.ak.instagram.com/090d06dad9cd11e2aa0912313817975d_102.mp4",
                     "width": 480,
                     "height": 480

--- a/instagram/models.py
+++ b/instagram/models.py
@@ -38,6 +38,11 @@ class Image(ApiModel):
 
 class Video(Image):
 
+    def __init__(self, *args, **kwargs):
+        # FIXME: this shows up in the api response, but is always '0'. what is this?
+        self.id = kwargs.pop('id', None)
+        super(Video, self).__init__(*args, **kwargs)
+
     def __unicode__(self):
         return "Video: %s" % self.url
 
@@ -117,7 +122,7 @@ class Media(ApiModel):
         new_media.caption = None
         if entry['caption']:
             new_media.caption = Comment.object_from_dictionary(entry['caption'])
-        
+
         new_media.tags = []
         if entry['tags']:
             for tag in entry['tags']:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="python-instagram-ext",
-      version="1.3.9",
+      version="1.3.10",
       description="Life extended Instagram API client",
       license="MIT",
       install_requires=["simplejson", "httplib2", "six"],


### PR DESCRIPTION
Starting on the morning of the 27th of september, the `videos`
attribute in the reponse to requests on a media endpoint contain
a new attribute: id, which always set to '0'. This crashed the
`Video.object_from_dictionary` calls for every response parsed by the
client that contained this tag as the id attribute wasn't present on
the Video model.

e.g.

```javascript

"videos": {
    "standard_resolution": {
	"width": 640,
	    "height": 359,
	    "url": "https://scontent.cdninstagram.com/t50.2886-16/21347497_688135741377726_1513723350453583872_n.mp4",
	    "id": "0" // wat.
    },
	"low_bandwidth": {
	    "width": 480,
	    "height": 269,
	    "url": "https://scontent.cdninstagram.com/t50.2886-16/21364131_115181835834691_686212731677704192_n.mp4",
	    "id": "0"
	},
	"low_resolution": {
	    "width": 480,
	    "height": 269,
	    "url": "https://scontent.cdninstagram.com/t50.2886-16/21364131_115181835834691_686212731677704192_n.mp4",
	    "id": "0"
	}
}

```

As of now, we have no idea what this attribute is supposed to signify
(it's not documented, nor is anything mentioned in the changelog) and
chances are this is a mistake on instagram's end. We've made it so the
Video model should be able to deal with the response changing back
should instagram remove the attribute again.

We've accounted for the two scenarios (the tag being there and it not
being there) in the tests by having one of the two video representations
have it and the other one not.